### PR TITLE
Small Docs Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # terminus-quick-cmds
 Quick commands for terminus
+
+# Shortcuts
+The default shortcut for opening the Quick Commands menu is `Alt+Q` for Windows.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "terminus-quick-cmds",
   "version": "1.1.0",
   "description": "Quick commands manager for Terminus",
+  "homepage": "https://github.com/Domain/terminus-quick-cmds",
   "keywords": [
     "terminus-plugin",
     "quick-commands"


### PR DESCRIPTION
This PR makes two small adjustments to the documentation:
1. Adds the default Windows shortcut for opening the quick-cmds dropdown to the README. I had to come browse the source to find the shortcut, this should save others the trouble.
2. Adds the `homepage` property to `package.json`. Terminus links users to the npmjs.org when they click on the plugin in the included plugin browser, but there was no link from that page to this repository. So I added it.