### PR TITLE
Solve the latest version can not be used

### DIFF
--- a/src/components/quickCmdsModal.component.ts
+++ b/src/components/quickCmdsModal.component.ts
@@ -45,6 +45,8 @@ export class QuickCmdsModalComponent {
             let currentTab = tab as TerminalTabComponent
             console.log("Sending " + cmd);
             currentTab.sendInput(cmd)
+        } else {
+            tab.focusedTab.session.write(e); //Solve the latest version can not be used
         }
     }
 


### PR DESCRIPTION
Solve the latest version can not be used
The latest version has no effect after clicking. After debugging, this modification is fine.